### PR TITLE
Make user name optional and expand tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Variables de entorno para el backend
+# Reemplaza los valores según tu configuración local
+DATABASE_URL="postgresql://user:password@localhost:5432/generadorbdd?schema=public"

--- a/README.md
+++ b/README.md
@@ -1,32 +1,41 @@
-# Backend Modules (NestJS Hexagonal + Prisma)
+# Generador BDD – Backend (NestJS + Prisma)
 
-Este paquete contiene **estructura y código** para añadir al proyecto NestJS recién creado con `nest new`.
+Este repositorio contiene la API del Generador BDD implementada con NestJS, Prisma y una arquitectura hexagonal básica.
 
-## Uso rápido
+## Requisitos previos
+
+- Node.js 20+
+- Base de datos PostgreSQL disponible
+- (Opcional) Docker para levantar servicios auxiliares
+
+## Puesta en marcha
 
 ```bash
-# 1) Crear proyecto NestJS
-nest new backend --strict
-cd backend
+# 1) Instala dependencias
+npm install
 
-# 2) Dependencias necesarias
-npm i @prisma/client class-validator class-transformer
-npm i -D prisma
+# 2) Configura las variables de entorno
+cp .env.example .env
+# edita .env con la cadena de conexión correcta para tu base de datos
 
-# 3) Copia estos archivos dentro del proyecto
-# (desde donde descargaste el zip)
-unzip -o backend-modules.zip -d .
-
-# 4) Variables de entorno
-cp -n .env.example .env
-
-# 5) Prisma: crear DB y migraciones
+# 3) Ejecuta migraciones de Prisma
 npx prisma migrate dev --name init
 
-# 6) Ejecuta
+# 4) Inicia el servidor en modo desarrollo
 npm run start:dev
 ```
 
-## Endpoints de prueba
-- POST `http://localhost:3001/users` body: `{ "email": "uno@ejemplo.com", "name": "Uno" }`
-- GET  `http://localhost:3001/users/{id}`
+El servidor se expone en `http://localhost:3001` (puerto configurado en `main.ts`).
+
+## Funcionalidad principal
+
+- `POST /users`: crea un usuario. El campo `name` es opcional; si no se envía, se infiere a partir del email.
+- `GET /users/:id`: obtiene un usuario por su identificador.
+
+## Pruebas
+
+Ejecuta las pruebas unitarias con:
+
+```bash
+npm test
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.2.0",
         "@prisma/client": "^6.16.2",
-        "class-transform": "^0.7.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "reflect-metadata": "^0.2.2",
@@ -4558,12 +4557,6 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.0.tgz",
       "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/class-transform": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/class-transform/-/class-transform-0.7.0.tgz",
-      "integrity": "sha512-j5O1TkgxsR836BOgyG83i5gKH3yaqdxMIbwviV3qJpcjGh1Vfil1CjtXn8RHgvtLvbosUutoewa+RA3Qty4SFA==",
       "license": "MIT"
     },
     "node_modules/class-transformer": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "^6.16.2",
-    "class-transform": "^0.7.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "reflect-metadata": "^0.2.2",

--- a/src/modules/users/application/create-user.usecase.spec.ts
+++ b/src/modules/users/application/create-user.usecase.spec.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { BadRequestException } from '@nestjs/common';
+import { CreateUserUseCase } from './create-user.usecase';
+import { User } from '../domain/user.entity';
+import { type UserRepository } from '../domain/user.repository';
+
+describe('CreateUserUseCase', () => {
+  let useCase: CreateUserUseCase;
+  let repo: jest.Mocked<UserRepository>;
+
+  beforeEach(() => {
+    repo = {
+      findByEmail: jest.fn(),
+      findById: jest.fn(),
+      create: jest.fn(),
+    };
+    useCase = new CreateUserUseCase(repo);
+  });
+
+  it('crea un usuario con el nombre proporcionado', async () => {
+    repo.findByEmail.mockResolvedValue(null);
+    repo.create.mockImplementation((user) => Promise.resolve(user));
+
+    const result = await useCase.execute({
+      email: 'usuario@example.com',
+      name: 'Nombre Personalizado',
+    });
+
+    expect(repo.findByEmail).toHaveBeenCalledWith('usuario@example.com');
+    expect(repo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'usuario@example.com',
+        name: 'Nombre Personalizado',
+      }),
+    );
+    expect(result.name).toBe('Nombre Personalizado');
+  });
+
+  it('infere el nombre desde el email cuando no se envía', async () => {
+    repo.findByEmail.mockResolvedValue(null);
+    repo.create.mockImplementation((user) => Promise.resolve(user));
+
+    const result = await useCase.execute({ email: 'sin.nombre@example.com' });
+
+    expect(repo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'sin.nombre' }),
+    );
+    expect(result.name).toBe('sin.nombre');
+  });
+
+  it('lanza una excepción si el email ya está registrado', async () => {
+    repo.findByEmail.mockResolvedValue(
+      new User('1', 'existente@example.com', 'Existente'),
+    );
+
+    await expect(
+      useCase.execute({ email: 'existente@example.com', name: 'Otro' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(repo.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/users/application/create-user.usecase.ts
+++ b/src/modules/users/application/create-user.usecase.ts
@@ -10,10 +10,18 @@ import { randomUUID } from 'crypto';
 export class CreateUserUseCase {
   constructor(@Inject(USER_REPOSITORY) private readonly repo: UserRepository) {}
 
-  async execute(input: { email: string; name: string }) {
+  async execute(input: { email: string; name?: string }) {
     const exists = await this.repo.findByEmail(input.email);
     if (exists) throw new BadRequestException('Email ya registrado');
-    const user = new User(randomUUID(), input.email, input.name);
+    const name = this.resolveName(input.email, input.name);
+    const user = new User(randomUUID(), input.email, name);
     return this.repo.create(user);
+  }
+
+  private resolveName(email: string, name?: string) {
+    const trimmed = name?.trim();
+    if (trimmed && trimmed.length > 0) return trimmed;
+    const [localPart] = email.split('@');
+    return localPart ?? email;
   }
 }

--- a/src/modules/users/interface/http/users.controller.spec.ts
+++ b/src/modules/users/interface/http/users.controller.spec.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersController } from './users.controller';
+import { CreateUserUseCase } from '../../application/create-user.usecase';
+import {
+  USER_REPOSITORY,
+  type UserRepository,
+} from '../../domain/user.repository';
+import { User } from '../../domain/user.entity';
+
+describe('UsersController', () => {
+  let controller: UsersController;
+  let createUser: CreateUserUseCase;
+  let repository: jest.Mocked<UserRepository>;
+
+  beforeEach(async () => {
+    repository = {
+      findByEmail: jest.fn(),
+      findById: jest.fn(),
+      create: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        {
+          provide: CreateUserUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: USER_REPOSITORY,
+          useValue: repository,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UsersController>(UsersController);
+    createUser = module.get<CreateUserUseCase>(CreateUserUseCase);
+  });
+
+  it('delegates en el caso de uso para crear un usuario', async () => {
+    const dto = {
+      email: 'nuevo@example.com',
+    } as Parameters<UsersController['create']>[0];
+    const created = new User('id', 'nuevo@example.com', 'nuevo');
+    (createUser.execute as jest.Mock).mockResolvedValue(created);
+
+    const result = await controller.create(dto);
+
+    expect(createUser.execute).toHaveBeenCalledWith(dto);
+    expect(result).toBe(created);
+  });
+
+  it('obtiene un usuario desde el repositorio por id', async () => {
+    const user = new User('abc', 'abc@example.com', 'abc');
+    repository.findById.mockResolvedValue(user);
+
+    await expect(controller.get('abc')).resolves.toBe(user);
+    expect(repository.findById).toHaveBeenCalledWith('abc');
+  });
+});

--- a/src/modules/users/interface/http/users.controller.ts
+++ b/src/modules/users/interface/http/users.controller.ts
@@ -9,7 +9,7 @@ import { IsEmail, IsOptional, IsString } from 'class-validator';
 
 class CreateUserDto {
   @IsEmail() email!: string;
-  @IsOptional() @IsString() name: string;
+  @IsOptional() @IsString() name?: string;
 }
 
 @Controller('users')


### PR DESCRIPTION
## Summary
- remove the unused class-transform package and provide an .env.example template
- make the CreateUser use case derive a default name when the DTO omits it and document the behavior in the README
- expand unit tests to cover the users use case and controller behaviors

## Testing
- npm run lint
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68d5d0378ccc83248cf4e70d3af53ffa